### PR TITLE
v1.5.3

### DIFF
--- a/gb-bot.php
+++ b/gb-bot.php
@@ -4,7 +4,7 @@
 * Plugin Name: GB&bull;BOT
 * Plugin URI: https://generationsbeyond.com/gb-bot/
 * Description: A collection of useful functions and features to proactively enhance your website.
-* Version: 1.5.2
+* Version: 1.5.3
 * Author: Generations Beyond
 * Author URI: https://generationsbeyond.com/
 * License: GPLv3
@@ -53,7 +53,7 @@ class GBBot
     {
         global $GBTC_ACTIVE;
 
-        $plugin_data = get_plugin_data(__FILE__, false);
+        $plugin_data = get_plugin_data(__FILE__, false, false);
 
         $this->plugin               = new stdClass();
         $this->plugin->name         = 'gb-bot';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gb-bot",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "=== GB&bull;BOT ===\r Contributors: genbeyond\r Requires at least: 6.1.1\r Tested up to: 6.5.3\r Stable tag: 1.2.1\r Requires PHP: 7.4\r License: GPLv3\r License URI: https://www.gnu.org/licenses/gpl-3.0.html",
   "main": "index.js",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: genbeyond
 Requires at least: 6.1.1
 Tested up to: 6.6.1
-Stable tag: 1.5.2
+Stable tag: 1.5.3
 Requires PHP: 7.4
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -33,6 +33,9 @@ Adds a button that returns the user to the top of the page when clicked.
 An easy way to identify all of the elements used in your Elementor-built website along with the locations of these elements to assist in the optimization process.
 
 == Changelog ==
+
+#### 1.5.3 - 2024-12-21
+* Fix: Minor conflict caused by new debug messaging in WordPress 6.7.0.
 
 #### 1.5.2 - 2024-09-09
 * General: License and Readme updates.


### PR DESCRIPTION
**Fix warning that was breaking Elementor editor in WP ^6.7.0**
`get_plugin_data` function was called without `false` as the third parameter, resulting in a translation attempt before translations were available.